### PR TITLE
feat: PVC support for kubernetes

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -59,7 +59,6 @@ class ExecutorSettings(ExecutorSettingsBase):
     )
     privileged: Optional[bool] = field(
         default=False,
-        init=False,
         metadata={
             "help": "This creates a privileged container which allows to "
             "mount storage inside the running container."
@@ -69,7 +68,7 @@ class ExecutorSettings(ExecutorSettingsBase):
         default=None,
         metadata={
             "help": "Mount the PVC with said name inside container in "
-            "`default_remote_prefix` location"
+            "`persistent_volume_claim_path` location"
         },
     )
     persistent_volume_claim_path: Optional[str] = field(


### PR DESCRIPTION
Hello

With this pull request I add the capability to mount a PVC in the K8S executor.

It expects the PVC to be created in advance.

The goal is to be able to mount arbitrary storages as disks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Kubernetes job execution settings with new options for privileged containers and persistent volume claims.
	- Added attributes for `privileged`, `persistent_volume_claim_name`, and `persistent_volume_claim_path` to improve storage management and security options. 

- **Improvements**
	- Implemented validations to prevent misconfigurations related to persistent volume claims. 
	- Updated job execution logic to support new configuration options, enhancing control over container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->