### PR TITLE
fix: Allow kubernetes versions 28 and 29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["snakemake", "plugin", "executor", "cloud", "kubernetes"]
 python = "^3.11"
 snakemake-interface-common = "^1.14.1"
 snakemake-interface-executor-plugins = "^8.0.2"
-kubernetes = "^27.2.0"
+kubernetes = ">=27.2.0,<30"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"


### PR DESCRIPTION
I am not able to test this plugin myself since I don’t have the necessary Kubernetes environment, but the release notes don’t show anything that would obviously cause problems.

https://github.com/kubernetes-client/python/blob/v29.0.0/CHANGELOG.md

In Fedora Linux, we have [`python-kubernetes`](https://src.fedoraproject.org/rpms/python-kubernetes) version 29.0.0, which is the current version, so we need to use that rather than pinning an older version.

In general, https://pypi.org/project/kubernetes/ bumps the major version number frequently but rarely seems to introduce large breaking changes. It may be less troublesome overall to avoid setting an upper bound on the version of this dependency at all.