### PR TITLE
fix: handle cases when running inside a kubernetes cluster

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -84,7 +84,10 @@ common_settings = CommonSettings(
 # Implementation of your executor
 class Executor(RemoteExecutor):
     def __post_init__(self):
-        kubernetes.config.load_kube_config()
+        try:
+            kubernetes.config.load_kube_config()
+        except kubernetes.config.config_exception.ConfigException:
+            config.load_incluster_config()
 
         self.k8s_cpu_scalar = self.workflow.executor_settings.cpu_scalar
         self.k8s_service_account_name = (


### PR DESCRIPTION
The current setup for the plugin assumes that we have a kubeconfig file used to connect to the cluster. However, this is not the case if the code submitting the job is itself running in a pod in the cluster, as we will need to use the default service account provided by the cluster  This modifies the init to catch any errors when loading a kubeconfig file and use the inlcuster configuration instead