### PR TITLE
feat: PVC support for kubernetes (continuation of #9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["snakemake", "plugin", "executor", "cloud", "kubernetes"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-snakemake-interface-common = "^1.14.1"
+snakemake-interface-common = "^1.17.3"
 snakemake-interface-executor-plugins = ">=9.0.0,<10.0.0"
 kubernetes = ">=27.2.0,<30"
 

--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -80,7 +80,7 @@ class ExecutorSettings(ExecutorSettingsBase):
         },
     )
     persistent_volumes: List[PersistentVolume] = field(
-        default=None,
+        default_factory=list,
         metadata={
             "help": "Mount the given persistent volumes under the given paths in each "
             "job container (<name>:<path>). ",

--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -74,9 +74,7 @@ class ExecutorSettings(ExecutorSettingsBase):
     )
     privileged: Optional[bool] = field(
         default=False,
-        metadata={
-            "help": "Create privileged containers for jobs."
-        },
+        metadata={"help": "Create privileged containers for jobs."},
     )
     persistent_volumes: List[PersistentVolume] = field(
         default_factory=list,

--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -75,8 +75,7 @@ class ExecutorSettings(ExecutorSettingsBase):
     privileged: Optional[bool] = field(
         default=False,
         metadata={
-            "help": "This creates a privileged container which allows to "
-            "mount storage inside the running container."
+            "help": "Create privileged containers for jobs."
         },
     )
     persistent_volumes: List[PersistentVolume] = field(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -30,6 +30,4 @@ class TestWorkflows(snakemake.common.tests.TestWorkflowsMinioPlayStorageBase):
         return snakemake.settings.types.RemoteExecutionSettings(
             seconds_between_status_checks=10,
             envvars=self.get_envvars(),
-            # TODO remove once we have switched to stable snakemake for dev
-            container_image="snakemake/snakemake:latest",
         )


### PR DESCRIPTION
@saulobejo in PR #9:
> With this pull request I add the capability to mount a PVC in the K8S executor.
> It expects the PVC to be created in advance.
> The goal is to be able to mount arbitrary storages as disks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new configuration options for Kubernetes job execution, enhancing support for privileged containers and Persistent Volume Claims (PVCs).
	- Improved the `ExecutorSettings` class to allow for flexible volume management and container privilege settings, enabling users to customize Kubernetes job configurations more effectively.
- **Bug Fixes**
	- Updated remote execution settings to remove dependency on the latest Docker image, promoting a more stable configuration in testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->