### PR TITLE
feat: Set implies_no_shared_fs=False

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -109,7 +109,7 @@ common_settings = CommonSettings(
     # Define whether your executor plugin implies that there is no shared
     # filesystem (True) or not (False).
     # This is e.g. the case for cloud execution.
-    implies_no_shared_fs=True,
+    implies_no_shared_fs=False,
     job_deploy_sources=True,
     pass_default_storage_provider_args=True,
     pass_default_resources_args=True,


### PR DESCRIPTION
The addition of persistent-volumes in v0.2.0 permits mounting of shared volume in each pod, which is effectively a shared-fs.  This PR removes the `implies_no_shared_fs` constraint on the kubernetes executor so that persistent volumes can be utilized as a shared-fs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the executor behavior to support shared filesystems, enhancing flexibility in cloud deployment scenarios.
  
- **Bug Fixes**
	- Adjusted the default setting for filesystem sharing, potentially improving job execution in varied environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->