### PR TITLE
feat: use k8s job API and improve status check robustness in case of injected containers

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -512,7 +512,9 @@ class Executor(RemoteExecutor):
         # Cancel all active jobs.
         for j in active_jobs:
             self._kubernetes_retry(
-                lambda: self.safe_delete_job(j.external_jobid, ignore_not_found=True)
+                lambda jobid=j.external_jobid: self.safe_delete_job(
+                    jobid, ignore_not_found=True
+                )
             )
 
     def shutdown(self):


### PR DESCRIPTION
Sometimes, just checking the status of a job is not enough, because apparently, depending on the cluster setup, there can be additional containers injected into pods that will prevent the job to detect that a pod is already terminated. This PR therefore checks the status of the snakemake container in addition to the job status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Switched the execution mechanism from Kubernetes pods to jobs, leading to enhanced task reliability.
  - Standardized container naming for greater consistency.

- **Improvements**
  - Upgraded error handling and log retrieval for smoother operation.
  - Refined cleanup procedures to ensure more dependable job management.
  - Enhanced resource management with updated toleration handling for GPU nodes. 
  - Introduced a new class for improved failure policy management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->