### PR TITLE
fix: output correct kubectl commands for changed submission approach (jobs instead of pods)

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -388,10 +388,7 @@ class Executor(RemoteExecutor):
             self.logger.error(f"Failed to create pod: {e}")
             raise WorkflowError(f"Failed to create pod: {e}")
 
-        self.logger.info(
-            "Get status with:\n"
-            "kubectl describe job {jobid}\n"
-        )
+        self.logger.info("Get status with:\n" "kubectl describe job {jobid}\n")
 
         self.report_job_submission(
             SubmittedJobInfo(job=job, external_jobid=jobid, aux={"pod": pod})

--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -390,8 +390,7 @@ class Executor(RemoteExecutor):
 
         self.logger.info(
             "Get status with:\n"
-            "kubectl describe pod {jobid}\n"
-            "kubectl logs {jobid}".format(jobid=jobid)
+            "kubectl describe job {jobid}\n"
         )
 
         self.report_job_submission(
@@ -479,8 +478,7 @@ class Executor(RemoteExecutor):
                 ):
                     msg = (
                         "For details, please issue:\n"
-                        f"kubectl describe job {j.external_jobid}\n"
-                        f"kubectl logs {j.external_jobid}"
+                        f"kubectl describe job {j.external_jobid}"
                     )
                     # failed
                     kube_log = self.log_path / f"{j.external_jobid}.log"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Simplified logging messages for Kubernetes job status checks.
	- The instructions now only reference the job-level command for retrieving job information, removing the previous guidance for fetching logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->