### PR TITLE
fix: delete k8s jobs after failure (important in setups where the system attaches sidecar pods, which can otherwise remain after failure)

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -479,13 +479,18 @@ class Executor(RemoteExecutor):
                         assert snakemake_container is not None
                         kube_log = self.log_path / f"{j.external_jobid}.log"
                         with open(kube_log, "w") as f:
-                            kube_log_content = self._kubernetes_retry(
-                                lambda pod_name=pod_name, container_name=snakemake_container.name: self.kubeapi.read_namespaced_pod_log(
+
+                            def read_log(
+                                pod_name=pod_name,
+                                container_name=snakemake_container.name,
+                            ):
+                                return self.kubeapi.read_namespaced_pod_log(
                                     name=pod_name,
                                     namespace=self.namespace,
                                     container=container_name,
                                 )
-                            )
+
+                            kube_log_content = self._kubernetes_retry(read_log)
                             print(kube_log_content, file=f)
                         aux_logs = [str(kube_log)]
                     else:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and logging for job status checks and failures.
	- Enhanced robustness when dealing with missing or failed Kubernetes jobs.
	- Refined pod log retrieval and job/pod cleanup processes for better reliability.

- **Refactor**
	- Updated job status checking to use asynchronous processing for better performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->