### PR TITLE
fix: handle container_statuses being None

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -448,7 +448,7 @@ class Executor(RemoteExecutor):
                     )
                 )
                 assert len(pods.items) <= 1
-                if pods.items:
+                if pods.items and pods.items[0].status.container_statuses is not None:
                     pod = pods.items[0]
                     snakemake_container = [
                         container


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by preventing errors when container statuses are missing from pods during job checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->