### PR TITLE
fix: job deletion propagation policy

### DIFF
--- a/snakemake_executor_plugin_kubernetes/__init__.py
+++ b/snakemake_executor_plugin_kubernetes/__init__.py
@@ -592,24 +592,11 @@ class Executor(RemoteExecutor):
     def safe_delete_job(self, jobid, ignore_not_found=True):
         import kubernetes.client
 
-        body = kubernetes.client.V1DeleteOptions()
+        body = kubernetes.client.V1DeleteOptions(propagation_policy="Foreground")
         self.logger.debug(f"Deleting job {jobid} in namespace {self.namespace}")
         try:
-            # Usually, kubernetes should delete the pods automatically
-            # when the job is deleted, but in some cases, this does not
-            # happen, so we delete the pods manually.
-            pods = self.kubeapi.list_namespaced_pod(
-                namespace=self.namespace,
-                label_selector=f"job-name={jobid}",
-            )
-            for pod in pods.items:
-                self.logger.debug(f"Deleting pod {pod.metadata.name} for job {jobid}")
-                self.kubeapi.delete_namespaced_pod(
-                    pod.metadata.name, self.namespace, body=body
-                )
-
             self.batchapi.delete_namespaced_job(
-                jobid, self.namespace, propagation_policy="Foreground", body=body
+                jobid, self.namespace, body=body
             )
         except kubernetes.client.rest.ApiException as e:
             if e.status == 404 and ignore_not_found:


### PR DESCRIPTION
The previous way of setting the propagation policy had no effect. As a result, child resources such as pods (among others) would not be properly destroyed.

see https://github.com/kubernetes-client/python/issues/234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified job-deletion behavior to rely on Kubernetes for background cleanup, improving reliability of resource removal.
  * Maintains existing error handling (continues to ignore already-missing jobs) so external error responses remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->